### PR TITLE
Add a minimalistic CLI

### DIFF
--- a/ede.cabal
+++ b/ede.cabal
@@ -49,6 +49,7 @@ library
     exposed-modules:
         Text.EDE
       , Text.EDE.Filters
+      , Paths_ede
 
     other-modules:
         Text.EDE.Internal.Compiler
@@ -71,6 +72,23 @@ library
       , transformers
       , unordered-containers
       , vector
+
+executable ed-e
+    default-language:  Haskell2010
+    main-is:           src/Main.hs
+
+    ghc-options:       -Wall -rtsopts "-with-rtsopts=-T -I0"
+
+    build-depends:
+        aeson
+      , base            >= 4.6 && < 5
+      , bytestring
+      , conduit         == 1.1.*
+      , conduit-extra   == 1.1.*
+      , directory
+      , ede
+      , optparse-applicative
+      , text
 
 test-suite golden
     default-language:  Haskell2010

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import           Control.Monad              (unless)
+import           Data.Aeson
+import qualified Data.ByteString.Lazy.Char8 as B
+import           Data.Conduit
+import qualified Data.Conduit.Attoparsec    as C
+import qualified Data.Conduit.Binary        as C
+import qualified Data.Text.Lazy.IO          as T
+import           Data.Version               (showVersion)
+import           Options.Applicative
+import           Paths_ede                  (version)
+import           System.Directory           (getPermissions, readable)
+import           System.IO                  (hSetBinaryMode, stdin)
+import qualified Text.EDE                   as EDE
+
+
+data Opts = Opts
+    { template :: FilePath
+    , bindings :: Maybe Object
+    } deriving (Eq, Show)
+
+parseOpts :: Parser Opts
+parseOpts = Opts
+    <$> ( strOption
+           ( short   't'
+          <> long    "template"
+          <> metavar "FILE"
+          <> help    "ED-E template to render."
+           )
+       <|> argument str (metavar "FILE")
+        )
+    <*> optional
+        ( nullOption
+          ( short   'd'
+         <> long    "data"
+         <> metavar "JSON"
+         <> eitherReader readJSON
+         <> help    ( "Bindings to make available in the environment, as JSON. "
+                   ++ "If not given, standard input is read.")
+          )
+        )
+  where
+    readJSON = either Left jObject . eitherDecode . B.pack
+
+optInfo :: ParserInfo Opts
+optInfo = info (helper <*> parseOpts)
+    ( fullDesc
+   <> header   ("ed-e v" ++ showVersion version)
+   <> progDesc "ED-E Template Engine CLI."
+    )
+
+main :: IO ()
+main = execParser optInfo >>= \ Opts{..} -> do
+    t <- readTemplate template
+    b <- maybe fromStdin return bindings
+    EDE.result errRender T.putStrLn $ EDE.render t b
+  where
+    readTemplate t = do
+        p <- getPermissions t
+        unless (readable p) $ errUnreadable t
+        EDE.parseFile t >>= EDE.result (error . show) return
+
+    fromStdin = do
+        hSetBinaryMode stdin True
+        j <- C.sourceHandle stdin $$ C.sinkParser json'
+        either error pure $ jObject j
+
+    errRender m  es = error . unlines $ "Error rendering template:" : show m : es
+    errUnreadable t = error $ t ++ " is not readable"
+
+
+jObject :: Value -> Either String Object
+jObject (Object o) = Right o
+jObject _          = Left  "Bindings must be given as a JSON object"


### PR DESCRIPTION
Note that the dependency on `conduit` / `conduit-extra` may seem overkill, but gives the nice property of exiting once a valid `aeson` `Value` has been read from stdin (or a parse error occurs).
