### PR TITLE
Add compatibility with base 4.8.0

### DIFF
--- a/src/Text/EDE/Internal/AST.hs
+++ b/src/Text/EDE/Internal/AST.hs
@@ -20,7 +20,7 @@ import Data.Aeson.Types
 import Data.Foldable
 import Data.List.NonEmpty      (NonEmpty(..))
 import Data.Maybe
-import Data.Monoid
+import Data.Monoid             (mempty)
 import Text.EDE.Internal.Types
 
 newtype Mu f = Mu (f (Mu f))

--- a/src/Text/EDE/Internal/Eval.hs
+++ b/src/Text/EDE/Internal/Eval.hs
@@ -24,7 +24,7 @@ import           Data.HashMap.Strict               (HashMap)
 import qualified Data.HashMap.Strict               as Map
 import           Data.List.NonEmpty                (NonEmpty(..))
 import qualified Data.List.NonEmpty                as NonEmpty
-import           Data.Monoid
+import           Data.Monoid                       ((<>), mempty)
 import           Data.Scientific                   (isFloating)
 import qualified Data.Text                         as Text
 import qualified Data.Text.Buildable               as Build


### PR DESCRIPTION
Ensures the `Alt` AST expression doesn't clash with the similarly named type from `base-4.8.0` by only importing the require functions (`(<>)` and `mempty`) from `Data.Monoid`.

Closes #11.