### PR TITLE
Export the Id type synonym.

### DIFF
--- a/src/Text/EDE.hs
+++ b/src/Text/EDE.hs
@@ -34,6 +34,7 @@ module Text.EDE
     -- ** Includes
     -- $resolvers
     , Resolver
+    , Id
     , includeMap
     , includeFile
 


### PR DESCRIPTION
The `Id` type synonym is being used by a [couple functions](https://hackage.haskell.org/package/ede-0.2.8.4/docs/Text-EDE.html#t:Resolver) exported from `Text.EDE`, but it is not exported itself.

This PR exports `Id` from `Text.EDE`.

I guess it would be ideal if `Id` had a comment, but after seeing that it is just a type synonym for `Text`, it's easy to guess it is just a generic identifier.