### PR TITLE
Fix hackage build errors

### DIFF
--- a/ede.cabal
+++ b/ede.cabal
@@ -65,7 +65,10 @@ library
         , Text.EDE.Internal.Syntax
         , Text.EDE.Internal.Types
 
-    ghc-options:       -Wall
+    if impl(ghc >= 8)
+        ghc-options:   -Wall -Wno-redundant-constraints
+    else
+        ghc-options:   -Wall
 
     build-depends:
           aeson                >= 0.7

--- a/src/Text/EDE/Internal/Eval.hs
+++ b/src/Text/EDE/Internal/Eval.hs
@@ -14,7 +14,6 @@
 
 module Text.EDE.Internal.Eval where
 
-import           Control.Applicative
 import           Control.Comonad.Cofree
 import           Control.Monad
 import           Control.Monad.Reader

--- a/src/Text/EDE/Internal/Filters.hs
+++ b/src/Text/EDE/Internal/Filters.hs
@@ -18,7 +18,6 @@
 
 module Text.EDE.Internal.Filters where
 
-import           Control.Applicative
 import           Data.Aeson                   (Array, Object, Value (..),
                                                encode)
 import qualified Data.Char                    as Char

--- a/src/Text/EDE/Internal/Types.hs
+++ b/src/Text/EDE/Internal/Types.hs
@@ -26,12 +26,10 @@ import           Control.Comonad
 import           Control.Comonad.Cofree
 import           Control.Lens
 import           Data.Aeson.Types             hiding (Result (..))
-import           Data.Foldable
 import           Data.HashMap.Strict          (HashMap)
 import           Data.List.NonEmpty           (NonEmpty (..))
 import qualified Data.List.NonEmpty           as NonEmpty
 import           Data.Monoid                  (mempty)
-import           Data.Semigroup
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Text.PrettyPrint.ANSI.Leijen (Doc, Pretty (..))
@@ -129,10 +127,6 @@ makeClassy ''Syntax
 
 -- | A function to resolve the target of an @include@ expression.
 type Resolver m = Syntax -> Id -> Delta -> m (Result Template)
-
-instance Applicative m => Semigroup (Resolver m) where
-    (f <> g) o k d = liftA2 (<|>) (f o k d) (g o k d) -- Haha!
-    {-# INLINE (<>) #-}
 
 -- | A parsed and compiled template.
 data Template = Template


### PR DESCRIPTION
* https://hackage.haskell.org/package/ede-0.2.8.5/reports/3

If we use Semigroup instance, we should use [Alt](https://hackage.haskell.org/package/base-4.9.0.0/candidate/docs/Data-Monoid.html#t:Alt) such as:

```haskell
type Resolver m = Syntax -> Id -> Delta -> m (Data.Monoid.Alt Result Template)
```

or

```haskell
newtype Resolver m = Resolver
    { runResolver :: Syntax -> Id -> Delta -> m (Result Template)
    }

instance Applicative m => Semigroup (Resolver m) where
    Resolver f <> Resolver g = Resolver $ \o k d -> liftA2 (<|>) (f o k d) (g o k d)
```