### PR TITLE
Fix GHC 8.0.2 build

### DIFF
--- a/src/Text/EDE/Internal/Types.hs
+++ b/src/Text/EDE/Internal/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveFoldable    #-}
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveTraversable #-}
@@ -8,6 +9,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
+
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances #-}
+#endif
 
 -- Module      : Text.EDE.Internal.Types
 -- Copyright   : (c) 2013-2015 Brendan Hay <brendan.g.hay@gmail.com>
@@ -130,7 +135,11 @@ makeClassy ''Syntax
 -- | A function to resolve the target of an @include@ expression.
 type Resolver m = Syntax -> Id -> Delta -> m (Result Template)
 
-instance Applicative m => Semigroup (Resolver m) where
+instance
+#if __GLASGOW_HASKELL__ >= 710
+  {-# OVERLAPPING #-}
+#endif
+  Applicative m => Semigroup (Resolver m) where
     (f <> g) o k d = liftA2 (<|>) (f o k d) (g o k d) -- Haha!
     {-# INLINE (<>) #-}
 


### PR DESCRIPTION
This library fails to build with GHC 8.0.2 because it mistakenly doesn't annotate its overlapping instances with `OVERLAPPING` annotations (8.0.2 is more strict about this than previous versions, see https://ghc.haskell.org/trac/ghc/ticket/12881). Luckily, it's easy to fix.