### PR TITLE
Migration from ansi-wl-pprint to prettyprinter

### DIFF
--- a/ede.cabal
+++ b/ede.cabal
@@ -68,27 +68,28 @@ library
     ghc-options:       -Wall
 
     build-depends:
-          aeson                >= 0.7
-        , ansi-wl-pprint       >= 0.6.6
-        , base                 >= 4.6   && < 5
-        , bifunctors           >= 4
-        , bytestring           >= 0.9
-        , comonad              >= 4.2
-        , directory            >= 1.2
-        , double-conversion    >= 2.0.2
-        , filepath             >= 1.2
-        , free                 >= 4.8
-        , lens                 >= 4.0
-        , mtl                  >= 2.1.3.1
-        , parsers              >= 0.12.1.1
-        , scientific           >= 0.3.1
-        , semigroups           >= 0.15
-        , text                 >= 1.2
-        , text-format          >= 0.3
-        , text-manipulate      >= 0.1.2
-        , trifecta             >= 1.6
-        , unordered-containers >= 0.2.3
-        , vector               >= 0.7.1
+          aeson                       >= 0.7
+        , base                        >= 4.6   && < 5
+        , bifunctors                  >= 4
+        , bytestring                  >= 0.9
+        , comonad                     >= 4.2
+        , directory                   >= 1.2
+        , double-conversion           >= 2.0.2
+        , filepath                    >= 1.2
+        , free                        >= 4.8
+        , lens                        >= 4.0
+        , mtl                         >= 2.1.3.1
+        , parsers                     >= 0.12.1.1
+        , prettyprinter               >= 1.2
+        , prettyprinter-ansi-terminal >= 1.1
+        , scientific                  >= 0.3.1
+        , semigroups                  >= 0.15
+        , text                        >= 1.2
+        , text-format                 >= 0.3
+        , text-manipulate             >= 0.1.2
+        , trifecta                    >= 2.1
+        , unordered-containers        >= 0.2.3
+        , vector                      >= 0.7.1
 
 test-suite golden
     default-language:  Haskell2010

--- a/src/Text/EDE.hs
+++ b/src/Text/EDE.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 
@@ -120,8 +121,9 @@ import           Data.Foldable                (foldrM)
 import           Data.HashMap.Strict          (HashMap)
 import qualified Data.HashMap.Strict          as Map
 import           Data.List.NonEmpty           (NonEmpty (..))
-import           Data.Monoid                  (mappend, mempty)
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
+#endif
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import qualified Data.Text.Lazy               as LText
@@ -134,8 +136,8 @@ import qualified Text.EDE.Internal.Eval       as Eval
 import qualified Text.EDE.Internal.Parser     as Parser
 import           Text.EDE.Internal.Quoting    (Term)
 import           Text.EDE.Internal.Syntax
-import           Text.EDE.Internal.Types
-import           Text.PrettyPrint.ANSI.Leijen (string)
+import           Text.EDE.Internal.Types      hiding ((</>))
+import           Data.Text.Prettyprint.Doc    (Pretty (..))
 import           Text.Trifecta.Delta
 
 -- | ED-E Version.
@@ -218,7 +220,7 @@ includeMap :: Monad m
            -> Resolver m          -- ^ Resolver for 'parseWith'.
 includeMap ts _ k _
     | Just v <- Map.lookup k ts = success v
-    | otherwise = failure ("unable to resolve " <> string (Text.unpack k))
+    | otherwise = failure ("unable to resolve " <> pretty (Text.unpack k))
       -- FIXME: utilise deltas in error messages
 
 -- | 'FilePath' resolver for @include@ expressions.
@@ -239,7 +241,7 @@ loadFile :: FilePath -> IO (Result ByteString)
 loadFile p = do
     e <- doesFileExist p
     if not e
-        then failure ("file " <> string p <> " doesn't exist.")
+        then failure ("file " <> pretty p <> " doesn't exist.")
         else BS.readFile p >>= success
 
 -- | Render an 'Object' using the supplied 'Template'.

--- a/src/Text/EDE/Internal/AST.hs
+++ b/src/Text/EDE/Internal/AST.hs
@@ -20,7 +20,6 @@ import Data.Aeson.Types
 import Data.Foldable
 import Data.List.NonEmpty      (NonEmpty(..))
 import Data.Maybe
-import Data.Monoid             (mempty)
 import Text.EDE.Internal.Types
 
 newtype Mu f = Mu (f (Mu f))

--- a/src/Text/EDE/Internal/Filters.hs
+++ b/src/Text/EDE/Internal/Filters.hs
@@ -18,14 +18,12 @@
 
 module Text.EDE.Internal.Filters where
 
-import           Control.Applicative
 import           Data.Aeson                   (Array, Object, Value (..),
                                                encode)
 import qualified Data.Char                    as Char
 import           Data.HashMap.Strict          (HashMap)
 import qualified Data.HashMap.Strict          as Map
 import           Data.Maybe
-import           Data.Monoid                  (mempty)
 import           Data.Scientific              (Scientific)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
@@ -36,7 +34,7 @@ import qualified Data.Text.Unsafe             as Text
 import qualified Data.Vector                  as Vector
 import           Text.EDE.Internal.Quoting
 import           Text.EDE.Internal.Types
-import           Text.PrettyPrint.ANSI.Leijen (Pretty (..), (<+>))
+import           Data.Text.Prettyprint.Doc    ((<+>))
 
 default (Integer)
 
@@ -160,7 +158,7 @@ qlist1 k f g = (k,) . TLam $ \case
     TVal (String t) -> pure . quote k 0 $ f t
     TVal (Array  v) -> pure . quote k 0 $ g v
     x               -> Failure $
-        "when expecting a String or Array, encountered" <+> pretty x
+        "when expecting a String or Array, encountered" <+> apretty x
 
 -- | Quote a comprehensive set of unary functions to create a binding
 -- that supports all collection types.
@@ -175,7 +173,7 @@ qcol1 k f g h = (k,) . TLam $ \case
     TVal (Object o) -> pure . quote k 0 $ g o
     TVal (Array  v) -> pure . quote k 0 $ h v
     x               -> Failure $
-        "when expecting a String, Object, or Array, encountered" <+> pretty x
+        "when expecting a String, Object, or Array, encountered" <+> apretty x
 
 headT, lastT, tailT, initT :: Text -> Value
 headT = text (Text.singleton . Text.unsafeHead)

--- a/src/Text/EDE/Internal/Parser.hs
+++ b/src/Text/EDE/Internal/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -34,9 +35,10 @@ import           Data.HashMap.Strict        (HashMap)
 import qualified Data.HashMap.Strict        as Map
 import           Data.List.NonEmpty         (NonEmpty (..))
 import qualified Data.List.NonEmpty         as NonEmpty
-import           Data.Monoid                (mempty)
 import           Data.Scientific
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
+#endif
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.Text.Encoding         as Text
@@ -63,6 +65,9 @@ instance HasSyntax Env where
 
 type Parser m =
     ( Monad m
+#if MIN_VERSION_base(4,13,0)
+    , MonadFail m
+#endif
     , MonadState Env m
     , TokenParsing m
     , DeltaParsing m
@@ -76,6 +81,9 @@ newtype EDE a = EDE { runEDE :: Tri.Parser a }
         , Applicative
         , Alternative
         , Monad
+#if MIN_VERSION_base(4,13,0)
+        , MonadFail
+#endif
         , MonadPlus
         , Parsing
         , CharParsing


### PR DESCRIPTION
Fixes #38 by switching to the latest trifecta-2.1
which also lets compilation of the ede package with ghc-8.8 or newer.

Also:

- Redundant imports were removed (retaining compatibility with older
  base packages).
- MonadFail feature implemented for base >= 4.13