### PR TITLE
Print annotated docs in the main application

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,6 +15,8 @@ import qualified Options.Applicative as Options
 import qualified Options.Applicative.Help.Pretty as Pretty
 import qualified System.Exit as Exit
 import qualified Text.EDE as EDE
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Terminal as PP
 
 data Options = Options
   { templateFile :: FilePath,
@@ -109,10 +111,10 @@ main = do
           >>= either fail pure . Parsec.parseOnly stdinParser
 
   EDE.parseFile (templateFile options) >>= \case
-    EDE.Failure err -> print err >> Exit.exitFailure
+    EDE.Failure err -> PP.putDoc (err <> PP.hardline) >> Exit.exitFailure
     EDE.Success tpl ->
       case EDE.render tpl ctx of
-        EDE.Failure err -> print err >> Exit.exitFailure
+        EDE.Failure err -> PP.putDoc (err <> PP.hardline) >> Exit.exitFailure
         EDE.Success output -> Text.Lazy.IO.putStr output
 
 stdinParser :: Parsec.Parser Aeson.Object

--- a/ede.cabal
+++ b/ede.cabal
@@ -94,12 +94,14 @@ executable ede
   main-is:        Main.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-A128m
   build-depends:
-    , aeson                 >=0.8
+    , aeson                        >=0.8
     , attoparsec
-    , bytestring            >=0.10.4
+    , bytestring                   >=0.10.4
     , ede
-    , optparse-applicative  >=0.11
-    , text                  >=1.2
+    , optparse-applicative         >=0.11
+    , prettyprinter                >=1.6
+    , prettyprinter-ansi-terminal  >=1.1
+    , text                         >=1.2
 
 test-suite tests
   import:         base


### PR DESCRIPTION
for this, `print` must be replaced with `putDoc`, otherwise errors thrown by `throwError` are shown as a flat text.