### PR TITLE
Move up the version bound for pretty printer

### DIFF
--- a/ede.cabal
+++ b/ede.cabal
@@ -79,7 +79,7 @@ library
     , lens                         >=4.0
     , mtl                          >=2.1.3.1
     , parsers                      >=0.12.1.1
-    , prettyprinter                >=1.6
+    , prettyprinter                >=1.7
     , prettyprinter-ansi-terminal  >=1.1
     , scientific                   >=0.3.1
     , text                         >=1.2
@@ -99,7 +99,6 @@ executable ede
     , bytestring                   >=0.10.4
     , ede
     , optparse-applicative         >=0.11
-    , prettyprinter                >=1.6
     , prettyprinter-ansi-terminal  >=1.1
     , text                         >=1.2
 


### PR DESCRIPTION
Otherwise main doesn't build. It fails with:
```
ede                > /run/user/1000/stack-768c282fabe8868e/ede-0.3.2.0/app/Main.hs:18:1: error:
ede                >     Could not find module ‘Prettyprinter’
ede                >     Use -v (or `:set -v` in ghci) to see a list of the files searched for.
ede                >    |
ede                > 18 | import qualified Prettyprinter as PP
ede                >    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ede                >
```

Moving this bound up lets stack figure out the right dependency.
I need stack for windows support.