### PR TITLE
ede: add prettyprinter dep for exe

### DIFF
--- a/ede.cabal
+++ b/ede.cabal
@@ -99,6 +99,7 @@ executable ede
     , bytestring                   >=0.10.4
     , ede
     , optparse-applicative         >=0.11
+    , prettyprinter
     , prettyprinter-ansi-terminal  >=1.1
     , text                         >=1.2
 


### PR DESCRIPTION
Removing the dependency entirely broke the exe target. Re-add with no bounds (inherit from library).