### PR TITLE
Build EDE with aeson >= 2.0

### DIFF
--- a/lib/Text/EDE.hs
+++ b/lib/Text/EDE.hs
@@ -295,9 +295,6 @@ renderWith ::
   Result Text.Lazy.Text
 renderWith fs (Template _ u ts) =
   fmap Text.Builder.toLazyText . Eval.render ts fs u
-#if MIN_VERSION_aeson(2,0,0)
-       . fromKeyMap
-#endif
 
 -- | /See:/ 'parse'
 eitherParse :: ByteString -> Either String Template

--- a/lib/Text/EDE.hs
+++ b/lib/Text/EDE.hs
@@ -296,7 +296,7 @@ renderWith ::
 renderWith fs (Template _ u ts) =
   fmap Text.Builder.toLazyText . Eval.render ts fs u
 #if MIN_VERSION_aeson(2,0,0)
-       . Eval.fromKeyMap
+       . fromKeyMap
 #endif
 
 -- | /See:/ 'parse'

--- a/lib/Text/EDE.hs
+++ b/lib/Text/EDE.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -125,7 +126,11 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Builder as Text.Builder
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter (Pretty (..))
+#else
 import Data.Text.Prettyprint.Doc (Pretty (..))
+#endif
 import Data.Version (Version)
 import qualified Paths_ede as Paths
 import qualified System.Directory as Directory
@@ -290,6 +295,9 @@ renderWith ::
   Result Text.Lazy.Text
 renderWith fs (Template _ u ts) =
   fmap Text.Builder.toLazyText . Eval.render ts fs u
+#if MIN_VERSION_aeson(2,0,0)
+       . Eval.fromKeyMap
+#endif
 
 -- | /See:/ 'parse'
 eitherParse :: ByteString -> Either String Template

--- a/lib/Text/EDE/Internal/Eval.hs
+++ b/lib/Text/EDE/Internal/Eval.hs
@@ -72,7 +72,11 @@ render ::
   HashMap Id (Exp Delta) ->
   HashMap Id Term ->
   Exp Delta ->
+#if MIN_VERSION_aeson(2,0,0)
   KeyMap Value ->
+#else
+  HashMap Id Value ->
+#endif
   Result Builder
 render ts fs e o =
   Reader.runReaderT (eval e >>= nf) (Env ts (stdlib <> fs) o)

--- a/lib/Text/EDE/Internal/Eval.hs
+++ b/lib/Text/EDE/Internal/Eval.hs
@@ -72,14 +72,10 @@ render ::
   HashMap Id (Exp Delta) ->
   HashMap Id Term ->
   Exp Delta ->
-  HashMap Id Value ->
+  KeyMap Value ->
   Result Builder
 render ts fs e o =
-#if MIN_VERSION_aeson(2,0,0)
-  Reader.runReaderT (eval e >>= nf) (Env ts (stdlib <> fs) $ toKeyMap o)
-#else
   Reader.runReaderT (eval e >>= nf) (Env ts (stdlib <> fs) o)
-#endif
   where
     nf (TVal v) = build (Trifecta.Delta.delta e) v
     nf _ =

--- a/lib/Text/EDE/Internal/Filters.hs
+++ b/lib/Text/EDE/Internal/Filters.hs
@@ -25,7 +25,6 @@ module Text.EDE.Internal.Filters where
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Array, Object, Value (..))
 #if MIN_VERSION_aeson(2,0,0)
-import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 #endif
 import qualified Data.Char as Char
@@ -125,7 +124,7 @@ stdlib =
       "at" @: (\x i -> x Vector.! i :: Value),
       -- object
 #if MIN_VERSION_aeson(2,0,0)
-      "keys" @: (map Key.toText . KeyMap.keys :: Object -> [Text]),
+      "keys" @: (map fromKey . KeyMap.keys :: Object -> [Text]),
       "elems" @: (map snd . KeyMap.toList :: Object -> [Value]),
 #else
       "keys" @: (HashMap.keys :: Object -> [Text]),

--- a/lib/Text/EDE/Internal/Filters.hs
+++ b/lib/Text/EDE/Internal/Filters.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExtendedDefaultRules #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -23,6 +24,10 @@ module Text.EDE.Internal.Filters where
 
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Array, Object, Value (..))
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+#endif
 import qualified Data.Char as Char
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
@@ -33,7 +38,11 @@ import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Encoding as Text.Lazy.Encoding
 import qualified Data.Text.Manipulate as Text.Manipulate
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter ((<+>))
+#else
 import Data.Text.Prettyprint.Doc ((<+>))
+#endif
 import qualified Data.Text.Unsafe as Text.Unsafe
 import qualified Data.Vector as Vector
 import Text.EDE.Internal.Quoting
@@ -100,8 +109,13 @@ stdlib =
       "justifyRight" @: (\x n -> Text.justifyRight n ' ' x),
       "center" @: (\x n -> Text.center n ' ' x),
       -- sequences
+#if MIN_VERSION_aeson(2,0,0)
+      qcol1 "length" Text.length KeyMap.size Vector.length,
+      qcol1 "empty" Text.null KeyMap.null Vector.null,
+#else
       qcol1 "length" Text.length HashMap.size Vector.length,
       qcol1 "empty" Text.null HashMap.null Vector.null,
+#endif
       qcol1 "reverse" Text.reverse id Vector.reverse,
       -- lists
       qlist1 "head" headT headV,
@@ -110,8 +124,13 @@ stdlib =
       qlist1 "init" initT initV,
       "at" @: (\x i -> x Vector.! i :: Value),
       -- object
+#if MIN_VERSION_aeson(2,0,0)
+      "keys" @: (map Key.toText . KeyMap.keys :: Object -> [Text]),
+      "elems" @: (map snd . KeyMap.toList :: Object -> [Value]),
+#else
       "keys" @: (HashMap.keys :: Object -> [Text]),
       "elems" @: (HashMap.elems :: Object -> [Value]),
+#endif
       -- , "map"        @: undefined
       -- , "filter"     @: undefined
       -- , "zip"        @: undefined

--- a/lib/Text/EDE/Internal/Parser.hs
+++ b/lib/Text/EDE/Internal/Parser.hs
@@ -36,6 +36,9 @@ import Control.Monad.State.Strict (MonadState, StateT)
 import qualified Control.Monad.State.Strict as State
 import Control.Monad.Trans (lift)
 import Data.Aeson.Types (Array, Object, Value (..))
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as KeyMap
+#endif
 import qualified Data.Bifunctor as Bifunctor
 import Data.ByteString (ByteString)
 import qualified Data.Char as Char
@@ -365,7 +368,11 @@ bool =
     <|> Trifecta.symbol "false" *> pure False
 
 object :: Parser m => m Object
+#if MIN_VERSION_aeson(2,0,0)
+object = KeyMap.fromList <$> Trifecta.braces (Trifecta.commaSep pair)
+#else
 object = HashMap.fromList <$> Trifecta.braces (Trifecta.commaSep pair)
+#endif
   where
     pair =
       (,)

--- a/lib/Text/EDE/Internal/Quoting.hs
+++ b/lib/Text/EDE/Internal/Quoting.hs
@@ -29,7 +29,6 @@ import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Array, Object, Value (..))
 #if MIN_VERSION_aeson(2,0,0)
-import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 #else
 import qualified Data.HashMap.Strict as HashMap
@@ -151,7 +150,7 @@ instance Unquote Collection where
       hashMap m =
 #if MIN_VERSION_aeson(2,0,0)
         Col (KeyMap.size m)
-          . map (Bifunctor.first $ Just . Key.toText)
+          . map (Bifunctor.first $ Just . fromKey)
           . sortBy (comparing fst)
           $ KeyMap.toList m
 #else

--- a/lib/Text/EDE/Internal/Types.hs
+++ b/lib/Text/EDE/Internal/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
@@ -38,9 +39,15 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter (Doc, Pretty (..))
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Terminal as PP
+#else
 import Data.Text.Prettyprint.Doc (Doc, Pretty (..))
 import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as PP
+#endif
 import Text.Trifecta.Delta (Delta, HasDelta)
 import qualified Text.Trifecta.Delta as Trifecta.Delta
 

--- a/lib/Text/EDE/Internal/Types.hs
+++ b/lib/Text/EDE/Internal/Types.hs
@@ -35,10 +35,6 @@ import Data.Aeson.Types (Object, Pair, Value (..))
 #if MIN_VERSION_aeson(2,0,0)
 import Data.Aeson.Key (Key)
 import qualified Data.Aeson.Key as Key
-import Data.Aeson.KeyMap (KeyMap)
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Bifunctor as Bifunctor
 import Data.Type.Coercion (coerceWith, sym)
 #endif
 import qualified Data.Functor.Classes as Functor.Classes
@@ -271,22 +267,4 @@ toKey =
     Just textCoercion -> coerceWith (sym textCoercion)
     Nothing -> Key.fromText
 {-# INLINEABLE toKey #-}
-
-fromKeyMap :: KeyMap Value -> HashMap Id Value
-fromKeyMap =
-  case KeyMap.coercionToHashMap of
-    Just hashMapCoercion ->
-      HashMap.mapKeys fromKey . coerceWith (sym hashMapCoercion)
-    Nothing ->
-      HashMap.fromList . map (Bifunctor.first fromKey) . KeyMap.toList
-{-# INLINEABLE fromKeyMap #-}
-
-toKeyMap :: HashMap Id Value -> KeyMap Value
-toKeyMap =
-  case KeyMap.coercionToHashMap of
-    Just hashMapCoercion ->
-      coerceWith hashMapCoercion . HashMap.mapKeys toKey
-    Nothing ->
-      KeyMap.fromList . map (Bifunctor.first toKey) . HashMap.toList
-{-# INLINEABLE toKeyMap #-}
 #endif


### PR DESCRIPTION
This commit includes also the newer Prettyprinter API.

I tried this with *ghc 9.2.1* and *aeson 2.0.2.0*. Build has only two unrelated warnings:

```ShellSession
$ cabal v1-build
Preprocessing library for ede-0.3.2.0..
Building library for ede-0.3.2.0..
[ 1 of 10] Compiling Paths_ede        ( dist/build/autogen/Paths_ede.hs, dist/build/Paths_ede.o, dist/build/Paths_ede.dyn_o )
[ 2 of 10] Compiling Text.EDE.Internal.Types ( lib/Text/EDE/Internal/Types.hs, dist/build/Text/EDE/Internal/Types.o, dist/build/Text/EDE/Internal/Types.dyn_o )

lib/Text/EDE/Internal/Types.hs:96:3: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘return’ definition detected
    in the instance declaration for ‘Monad Result’.
    ‘return’ will eventually be removed in favour of ‘pure’
    Either remove definition for ‘return’ (recommended) or define as ‘return = pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
   |
96 |   return = Success
   |   ^^^^^^^^^^^^^^^^

lib/Text/EDE/Internal/Types.hs:104:3: warning: [-Wnoncanonical-monad-instances]
    Noncanonical ‘pure = return’ definition detected
    in the instance declaration for ‘Applicative Result’.
    Move definition from ‘return’ to ‘pure’
    See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
    |
104 |   pure = return
    |   ^^^^^^^^^^^^^
[ 3 of 10] Compiling Text.EDE.Internal.Syntax ( lib/Text/EDE/Internal/Syntax.hs, dist/build/Text/EDE/Internal/Syntax.o, dist/build/Text/EDE/Internal/Syntax.dyn_o )
[ 4 of 10] Compiling Text.EDE.Internal.Quoting ( lib/Text/EDE/Internal/Quoting.hs, dist/build/Text/EDE/Internal/Quoting.o, dist/build/Text/EDE/Internal/Quoting.dyn_o )
[ 5 of 10] Compiling Text.EDE.Internal.Filters ( lib/Text/EDE/Internal/Filters.hs, dist/build/Text/EDE/Internal/Filters.o, dist/build/Text/EDE/Internal/Filters.dyn_o )
[ 6 of 10] Compiling Text.EDE.Filters ( lib/Text/EDE/Filters.hs, dist/build/Text/EDE/Filters.o, dist/build/Text/EDE/Filters.dyn_o )
[ 7 of 10] Compiling Text.EDE.Internal.Eval ( lib/Text/EDE/Internal/Eval.hs, dist/build/Text/EDE/Internal/Eval.o, dist/build/Text/EDE/Internal/Eval.dyn_o )
[ 8 of 10] Compiling Text.EDE.Internal.AST ( lib/Text/EDE/Internal/AST.hs, dist/build/Text/EDE/Internal/AST.o, dist/build/Text/EDE/Internal/AST.dyn_o )
[ 9 of 10] Compiling Text.EDE.Internal.Parser ( lib/Text/EDE/Internal/Parser.hs, dist/build/Text/EDE/Internal/Parser.o, dist/build/Text/EDE/Internal/Parser.dyn_o )
[10 of 10] Compiling Text.EDE         ( lib/Text/EDE.hs, dist/build/Text/EDE.o, dist/build/Text/EDE.dyn_o )
Preprocessing executable 'ede' for ede-0.3.2.0..
Building executable 'ede' for ede-0.3.2.0..
[1 of 2] Compiling Main             ( app/Main.hs, dist/build/ede/ede-tmp/Main.o )
[2 of 2] Compiling Paths_ede        ( dist/build/ede/autogen/Paths_ede.hs, dist/build/ede/ede-tmp/Paths_ede.o )
Linking dist/build/ede/ede ...
Preprocessing test suite 'tests' for ede-0.3.2.0..
Building test suite 'tests' for ede-0.3.2.0..
[1 of 2] Compiling Paths_ede        ( dist/build/tests/autogen/Paths_ede.hs, dist/build/tests/tests-tmp/Paths_ede.o )
[2 of 2] Compiling Main             ( test/Main.hs, dist/build/tests/tests-tmp/Main.o )
Linking dist/build/tests/tests ...
```

There are 2 test failures (probably they failed before the fix as well):

```ShellSession
$ cabal v1-test
Preprocessing library for ede-0.3.2.0..
Building library for ede-0.3.2.0..
Preprocessing test suite 'tests' for ede-0.3.2.0..
Building test suite 'tests' for ede-0.3.2.0..
Running 1 test suites...
Test suite tests: RUNNING...
ED-E
  /home/lyokha/devel/ede/test/resources/empty.ede:                 OK
  /home/lyokha/devel/ede/test/resources/numbers.ede:               OK
  /home/lyokha/devel/ede/test/resources/include.ede:               OK
  /home/lyokha/devel/ede/test/resources/text.ede:                  OK
  /home/lyokha/devel/ede/test/resources/variables.ede:             OK
  /home/lyokha/devel/ede/test/resources/comments.ede:              OK
  /home/lyokha/devel/ede/test/resources/defined.ede:               OK
  /home/lyokha/devel/ede/test/resources/raw.ede:                   OK
  /home/lyokha/devel/ede/test/resources/list-sorting.ede:          OK
  /home/lyokha/devel/ede/test/resources/whitespace.ede:            FAIL
    Test output was different from '/home/lyokha/devel/ede/test/resources/whitespace.golden'. Output of ["diff","-u","/home/lyokha/devel/ede/test/resources/whitespace.golden","/tmp/whitespace26628-9.actual"]:
    --- /home/lyokha/devel/ede/test/resources/whitespace.golden	2021-11-14 12:58:39.879032807 +0300
    +++ /tmp/whitespace26628-9.actual	2021-11-17 00:51:41.640854788 +0300
    @@ -6,6 +6,8 @@
     
       
     
    +       
            test  
    +    
       
     
    
    Use -p '/\/home\/lyokha\/devel\/ede\/test\/resources\/whitespace.ede/' to rerun this test only.
  /home/lyokha/devel/ede/test/resources/relational-conditions.ede: OK
  /home/lyokha/devel/ede/test/resources/case.ede:                  OK
  /home/lyokha/devel/ede/test/resources/binding.ede:               OK
  /home/lyokha/devel/ede/test/resources/null.ede:                  OK
  /home/lyokha/devel/ede/test/resources/single-line.ede:           OK
  /home/lyokha/devel/ede/test/resources/newlines.ede:              OK
  /home/lyokha/devel/ede/test/resources/syntax.ede:                OK
  /home/lyokha/devel/ede/test/resources/list-transformation.ede:   OK
  /home/lyokha/devel/ede/test/resources/text-casing.ede:           OK
  /home/lyokha/devel/ede/test/resources/polymorphic-show.ede:      FAIL
    Test output was different from '/home/lyokha/devel/ede/test/resources/polymorphic-show.golden'. Output of ["diff","-u","/home/lyokha/devel/ede/test/resources/polymorphic-show.golden","/tmp/polymorphic-show26628-19.actual"]:
    --- /home/lyokha/devel/ede/test/resources/polymorphic-show.golden	2021-11-14 12:58:39.878032850 +0300
    +++ /tmp/polymorphic-show26628-19.actual	2021-11-17 00:51:41.668853610 +0300
    @@ -4,4 +4,4 @@
     1.0
     ["a","b","c","d","e"]
     [1,2,3,4,5]
    -{"foo":"x","bar":"y"}
    +{"bar":"y","foo":"x"}
    
    Use -p '/\/home\/lyokha\/devel\/ede\/test\/resources\/polymorphic-show.ede/' to rerun this test only.
  /home/lyokha/devel/ede/test/resources/nesting.ede:               OK
  /home/lyokha/devel/ede/test/resources/boolean-conditions.ede:    OK
  /home/lyokha/devel/ede/test/resources/text-whitespace.ede:       OK
  /home/lyokha/devel/ede/test/resources/text-substitution.ede:     OK
  /home/lyokha/devel/ede/test/resources/sequence-length.ede:       OK
  /home/lyokha/devel/ede/test/resources/sequence-empty.ede:        OK
  /home/lyokha/devel/ede/test/resources/text-ellipsis.ede:         OK
  /home/lyokha/devel/ede/test/resources/boolean-operands.ede:      OK
  /home/lyokha/devel/ede/test/resources/text-indentation.ede:      OK
  /home/lyokha/devel/ede/test/resources/list-subdivision.ede:      OK
  /home/lyokha/devel/ede/test/resources/looping.ede:               OK
  /home/lyokha/devel/ede/test/resources/literals.ede:              OK

2 out of 32 tests failed (0.08s)

Test suite tests: FAIL
Test suite logged to: dist/test/ede-0.3.2.0-tests.log
0 of 1 test suites (0 of 1 test cases) passed.
```