### PR TITLE
Fix building with optparse-applicative 0.18 and aeson 2.2, fixes #50

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -5,6 +6,9 @@ module Main (main) where
 
 import qualified Control.Monad.Fail as Fail
 import qualified Data.Aeson as Aeson
+#ifdef VERSION_attoparsec_aeson
+import qualified Data.Aeson.Parser as Aeson
+#endif
 import qualified Data.Attoparsec.ByteString as Parsec
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as ByteString.Lazy
@@ -41,8 +45,8 @@ optionsParser =
           ( Options.long "context-file"
               <> Options.metavar "PATH"
               <> Options.help
-                "Path of a file containing a JSON object which is used \
-                \as the template context"
+                ("Path of a file containing a JSON object which is used " <>
+                 "as the template context")
           )
       )
     <*> Options.optional
@@ -63,26 +67,32 @@ parserInfo =
   where
     usage =
       Pretty.vcat
-        [ Pretty.empty,
+        [ Pretty.emptyDoc,
           "The --context-file and --context-json options are processed as follows:",
           Pretty.indent 2 "1.)"
             Pretty.<+> ( Pretty.align
-                           ( "Both are provided"
-                               Pretty.<$$> "Both objects are merged into one with the keys of \
-                                           \--context-json taking precedence over those in the \
-                                           \file provided by --context-file."
+                           ( Pretty.vcat
+                               [ "Both are provided",
+                                 "Both objects are merged into one with the keys of " <>
+                                 "--context-json taking precedence over those in the " <>
+                                 "file provided by --context-file."
+                               ]
                            )
                        ),
           Pretty.indent 2 "2.)"
             Pretty.<+> ( Pretty.align
-                           ( "None of them are provided"
-                               Pretty.<$$> "The JSON object is read from STDIN."
+                           ( Pretty.vcat
+                               [ "None of them are provided",
+                                 "The JSON object is read from STDIN."
+                               ]
                            )
                        ),
           Pretty.indent 2 "3.)"
             Pretty.<+> ( Pretty.align
-                           ( "One of them is provided"
-                               Pretty.<$$> "The JSON object is read from the supplied option."
+                           ( Pretty.vcat
+                               [ "One of them is provided",
+                                 "The JSON object is read from the supplied option."
+                               ]
                            )
                        )
         ]

--- a/ede.cabal
+++ b/ede.cabal
@@ -45,6 +45,9 @@ source-repository head
   type:     git
   location: git://github.com/brendanhay/ede.git
 
+flag AttoparsecAeson
+  description: Build attoparsec-aeson.
+
 common base
   default-language: Haskell2010
   ghc-options:
@@ -95,15 +98,22 @@ executable ede
   main-is:        Main.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-A128m
   build-depends:
-    , aeson                        >=1.4
     , attoparsec                   >=0.13
     , bytestring                   >=0.10.4
     , ede
-    , optparse-applicative         >=0.11
-    , prettyprinter                >= 1.7
+    , optparse-applicative         >=0.18
+    , prettyprinter                >=1.7
     , prettyprinter-ansi-terminal  >=1.1
     , text                         >=1.2
     , unordered-containers         >=0.2.3
+
+  if flag(AttoparsecAeson)
+    build-depends:
+      , aeson                      >=2.2
+      , attoparsec-aeson           >=2.2
+  else
+    build-depends:
+      , aeson                      >=1.4
 
 test-suite tests
   import:         base


### PR DESCRIPTION
1. Require *optparse-applicative >=0.18*, this seems to be harmless.
2. Introduce automatic flag `AttoparsecAeson` to build with *aeson >=2.2*.

Note that *app/Main.hs* got some CPP for *attoparsec-aeson* which forced replacement of Haskell-style line-breaks by operator `(<>)`.